### PR TITLE
Allow binding to a specific address.

### DIFF
--- a/hooktftp.go
+++ b/hooktftp.go
@@ -142,7 +142,7 @@ func main() {
 		HOOKS = append(HOOKS, hook)
 	}
 
-	addr, err := net.ResolveUDPAddr("udp", ":"+conf.Port)
+	addr, err := net.ResolveUDPAddr("udp", conf.Host+":"+conf.Port)
 	if err != nil {
 		fmt.Println("Failed to resolve address", err)
 		return
@@ -154,7 +154,7 @@ func main() {
 		return
 	}
 
-	fmt.Println("Listening on", conf.Port)
+	fmt.Println("Listening on", conf.Host, conf.Port)
 
 	if conf.User != "" {
 		err := DropPrivileges(conf.User)


### PR DESCRIPTION
It looks like you intended to implement this because the variables were already defined in the config - this is just a quick 'n dirty hack to make it work.