### PR TITLE
Switch from syscall to the sys/unix package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
   - go get
 script: make test
 go:
-  - 1.1
+  - 1.4

--- a/drop_privileges.go
+++ b/drop_privileges.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os/user"
 	"strconv"
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 func DropPrivileges(username string) error {
@@ -23,17 +23,17 @@ func DropPrivileges(username string) error {
 	}
 
 	// TODO: should set secondary groups too
-	err = syscall.Setgroups([]int{gid})
+	err = unix.Setgroups([]int{gid})
 	if err != nil {
 		return err
 	}
 
-	err = syscall.Setgid(gid)
+	err = unix.Setregid(gid, gid)
 	if err != nil {
 		return err
 	}
 
-	err = syscall.Setuid(uid)
+	err = unix.Setreuid(uid, uid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The syscall package is deprecated and causes setgid/setuid to fail on linux/i386.
This commit switches the setuid/setgid calls to sys/unix, however this will only work for golang 1.4+.

From http://golang.org/pkg/syscall/:

NOTE: This package is locked down. Code outside the standard Go repository should be migrated to use the corresponding package in the go.sys subrepository. That is also where updates required by new systems or versions should be applied. See https://golang.org/s/go1.4-syscall for more information.