### PR TITLE
Switch from syscall to the sys/unix package, closes #9

### DIFF
--- a/src/drop_privileges.go
+++ b/src/drop_privileges.go
@@ -3,7 +3,8 @@ package main
 import (
 	"os/user"
 	"strconv"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func DropPrivileges(username string) error {
@@ -23,21 +24,20 @@ func DropPrivileges(username string) error {
 	}
 
 	// TODO: should set secondary groups too
-	err = syscall.Setgroups([]int{gid})
+	err = unix.Setgroups([]int{gid})
 	if err != nil {
 		return err
 	}
 
-	err = syscall.Setgid(gid)
+	err = unix.Setregid(gid, gid)
 	if err != nil {
 		return err
 	}
 
-	err = syscall.Setuid(uid)
+	err = unix.Setreuid(uid, uid)
 	if err != nil {
 		return err
 	}
 
 	return nil
 }
-


### PR DESCRIPTION
The [commit](https://github.com/tftp-go-team/hooktftp/commit/5ce7df67eb1c2b5fc811b8804248549e1c71c78c) is originally from @sspans, but we can't merge it since it required to fix conflicts and he deleted his fork.