### PR TITLE
Whitelist

### DIFF
--- a/src/config/parse_yaml.go
+++ b/src/config/parse_yaml.go
@@ -5,10 +5,11 @@ import (
 )
 
 type HookDef struct {
-	Description string "description"
-	Type        string "type"
-	Regexp      string "regexp"
-	Template    string "template"
+	Description string   "description"
+	Type        string   "type"
+	Regexp      string   "regexp"
+	Template    string   "template"
+	Whitelist   []string "whitelist"
 }
 
 type Config struct {
@@ -32,6 +33,10 @@ func (d *HookDef) GetDescription() string {
 
 func (d *HookDef) GetRegexp() string {
 	return d.Regexp
+}
+
+func (d *HookDef) GetWhitelist() []string {
+	return d.Whitelist
 }
 
 func ParseYaml(yaml []byte) (*Config, error) {

--- a/src/config/parse_yaml_test.go
+++ b/src/config/parse_yaml_test.go
@@ -28,6 +28,28 @@ hooks:
 	},
 }
 
+var shellHookWithWhitelistTest = yamlExample{
+	`
+hooks:
+  - type: shell
+    regexp: ^(.*)$
+    template: echo hello
+    whitelist:
+      - allowed
+      - allowed_too
+`,
+	Config{
+		HookDefs: []HookDef{
+			{
+				Type:      "shell",
+				Regexp:    "^(.*)$",
+				Template:  "echo hello",
+				Whitelist: []string{"allowed", "allowed_too"},
+			},
+		},
+	},
+}
+
 var httpHookTest = yamlExample{
 	`
 hooks:
@@ -89,6 +111,7 @@ user: hook
 		},
 	},
 	shellHookTest,
+	shellHookWithWhitelistTest,
 	httpHookTest,
 }
 

--- a/src/hooks/hooks_test.go
+++ b/src/hooks/hooks_test.go
@@ -207,20 +207,18 @@ func TestHooks(t *testing.T) {
 			return
 		}
 
-		if hookResult == nil {
-			return
-		}
+		if hookResult != nil {
+			data, err := ioutil.ReadAll(hookResult.Stdout)
+			if err != nil {
+				t.Error("Failed to read file", testCase.hookDef, hookResult.Stdout)
+				return
+			}
 
-		data, err := ioutil.ReadAll(hookResult.Stdout)
-		if err != nil {
-			t.Error("Failed to read file", testCase.hookDef, hookResult.Stdout)
-			return
-		}
+			res := string(data[:len(testCase.expected)])
 
-		res := string(data[:len(testCase.expected)])
-
-		if res != testCase.expected {
-			t.Errorf("Expected to find '%v' from file but got '%v'", testCase.expected, res)
+			if res != testCase.expected {
+				t.Errorf("Expected to find '%v' from file but got '%v'", testCase.expected, res)
+			}
 		}
 	}
 }

--- a/src/hooks/hooks_test.go
+++ b/src/hooks/hooks_test.go
@@ -186,6 +186,47 @@ func TestHooks(t *testing.T) {
 				return nil
 			},
 		},
+		// Test whitelist: url OK
+		{
+			&config.HookDef{
+				Type:      "http",
+				Regexp:    "url\\/(.+)$",
+				Template:  ts.URL + "/test/$1",
+				Whitelist: []string{"^" + ts.URL + ".*"},
+			},
+			"url/web.txt",
+			"RES:web.txt",
+			noError,
+		},
+		// Test whitelist: empty whitelist is similar to whitelist
+		{
+			&config.HookDef{
+				Type:      "http",
+				Regexp:    "url\\/(.+)$",
+				Template:  ts.URL + "/test/$1",
+				Whitelist: []string{},
+			},
+			"url/web.txt",
+			"RES:web.txt",
+			noError,
+		},
+		// Test whitelist: url not in whitelist
+		{
+			&config.HookDef{
+				Type:      "http",
+				Regexp:    "url\\/(.+)$",
+				Template:  ts.URL + "/bad",
+				Whitelist: []string{"^http://www.google.com", "^http://www.github.com/"},
+			},
+			"url/bad.txt",
+			"bad response",
+			func(err error) error {
+				if err == nil {
+					return fmt.Errorf("Bad url response test failed: Expected to have an error")
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, testCase := range hookTestCases {

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -2,13 +2,13 @@ package logger
 
 import (
 	"fmt"
-	"os"
 	"log/syslog"
+	"os"
 )
 
 var (
 	instance *syslog.Writer
-	err error
+	err      error
 )
 
 func Initialize(tag string) error {
@@ -91,4 +91,3 @@ func Warning(format string, a ...interface{}) (err error) {
 	}
 	return instance.Warning(str)
 }
-

--- a/src/regexptransform/regexp_transform.go
+++ b/src/regexptransform/regexp_transform.go
@@ -8,8 +8,10 @@ import (
 
 var NO_MATCH = errors.New("No match")
 var BAD_GROUPS = errors.New("Regexp has too few groups")
+
 type Escape func(string) string
 type Transform func(string) (string, error)
+
 var fieldPat = regexp.MustCompile("\\$([0-9]+)")
 
 func NewRegexpTransform(regexpStr, template string, escape Escape) (Transform, error) {
@@ -27,7 +29,7 @@ func NewRegexpTransform(regexpStr, template string, escape Escape) (Transform, e
 
 		var err error
 
-		output := fieldPat.ReplaceAllStringFunc(template, func (f string) string {
+		output := fieldPat.ReplaceAllStringFunc(template, func(f string) string {
 			i, _ := strconv.Atoi(fieldPat.FindAllStringSubmatch(f, -1)[0][1])
 			if len(fields)-1 < i {
 				err = BAD_GROUPS
@@ -40,7 +42,7 @@ func NewRegexpTransform(regexpStr, template string, escape Escape) (Transform, e
 			return "", err
 		}
 
-		return output,  err
+		return output, err
 
 	}, nil
 }

--- a/src/regexptransform/regexp_transform_test.go
+++ b/src/regexptransform/regexp_transform_test.go
@@ -9,12 +9,12 @@ func dummyEscape(s string) string {
 }
 
 type TransformTest struct {
-	regexp string
+	regexp   string
 	template string
-	escape Escape
-	input string
-	output string
-	err error
+	escape   Escape
+	input    string
+	output   string
+	err      error
 }
 
 var TransformTests = []TransformTest{
@@ -110,5 +110,3 @@ func TestTranforms(t *testing.T) {
 
 	}
 }
-
-


### PR DESCRIPTION
Allow to specify a regexp "whitelist" in configuration to limit the filenames that can be downloaded.

With the following configuration file:

```
hooks:
  - type: http
     regexp: ^https%3A//(.*)$
     template: https://$1
     whitelist:
       - ^http://www.google.com.*
```

hooktftp only allow downloads for files starting with http://www.google.com.

The whitelist is not hook specific, so it can also be specified for the shell and file hooks.

I created a pull request in case you're interested @epeli  @sspans 
In case you're not, I will probably merge it to master tomorrow.

