### PR TITLE
Update required Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ hooks:
 
 ### Compiling from sources
 
-[Install Go][] (1.1 or later), make sure you have git and bazaar too.
+[Install Go][] (1.8 or later), make sure you have git and bazaar too.
 Assuming you've successfully set up GOPATH and have GOPATH/bin on your path, simply:
     
     make build


### PR DESCRIPTION
README still states 1.1 or later, but 1.8 is required since d29ee524ae88c3b148ab0aedc74cc38e00e0e89d.