### PR TITLE
Add exit codes

### DIFF
--- a/cmd/hooktftp/main.go
+++ b/cmd/hooktftp/main.go
@@ -1,7 +1,9 @@
 package main
 
+import "os"
+
 import hooktftp "github.com/tftp-go-team/hooktftp/internal"
 
 func main() {
-	hooktftp.HookTFTP()
+	os.Exit(hooktftp.HookTFTP())
 }


### PR DESCRIPTION
Currently HookTFTP will fail without return a proper exit code, often interpreted as success (e.g. SystemD service manager).
This MR adds different exit codes to help detect failures.